### PR TITLE
Separation Model

### DIFF
--- a/app/src/main/java/com/dev_juyoung/cro_mvp_sample/ImageAdapter.java
+++ b/app/src/main/java/com/dev_juyoung/cro_mvp_sample/ImageAdapter.java
@@ -34,7 +34,7 @@ public class ImageAdapter extends RecyclerView.Adapter<ImageAdapter.ViewHolder> 
 
     @Override
     public void addItems(ArrayList<Integer> items) {
-        Log.i(TAG, "Presenter -> AdapterModel: 신규 데이터 추가 요청 이벤트.");
+        Log.i(TAG, "AdapterView: Presenter로 부터 신규 데이터 전달 받음.");
 
         // 신규 데이터 추가.
         if (data == null) {
@@ -46,7 +46,7 @@ public class ImageAdapter extends RecyclerView.Adapter<ImageAdapter.ViewHolder> 
 
     @Override
     public void updateItems(ArrayList<Integer> items) {
-        Log.i(TAG, "Presenter -> AdapterModel: 데이터 갱신 요청 이벤트.");
+        Log.i(TAG, "AdapterView: Presenter로 부터 갱신 데이터 전달 받음.");
 
         // 데이터 갱신.
         data = items;
@@ -54,7 +54,7 @@ public class ImageAdapter extends RecyclerView.Adapter<ImageAdapter.ViewHolder> 
 
     @Override
     public void updateView() {
-        Log.i(TAG, "Presenter -> AdapterView: UI 갱신 요청 이벤트.");
+        Log.i(TAG, "AdapterView: Presenter로 부터 UI 갱신 요청 전달 받음.");
 
         notifyDataSetChanged();
     }
@@ -74,7 +74,7 @@ public class ImageAdapter extends RecyclerView.Adapter<ImageAdapter.ViewHolder> 
 
         @OnClick(R.id.imageView)
         void imageViewTouchUp() {
-            Log.i(TAG, "AdapterView -> Presenter: 사용자 클릭 이벤트 전달.");
+            Log.i(TAG, "AdapterView: 사용자 클릭 이벤트 발생.");
 
             if (onItemClickListener != null) {
                 onItemClickListener.onItemClick(getAdapterPosition());

--- a/app/src/main/java/com/dev_juyoung/cro_mvp_sample/MainActivity.java
+++ b/app/src/main/java/com/dev_juyoung/cro_mvp_sample/MainActivity.java
@@ -8,7 +8,7 @@ import android.util.Log;
 import android.widget.Toast;
 
 import com.dev_juyoung.cro_mvp_sample.base.BaseActivity;
-import com.dev_juyoung.cro_mvp_sample.data.ImageData;
+import com.dev_juyoung.cro_mvp_sample.data.ImageRepository;
 
 import butterknife.BindView;
 
@@ -46,8 +46,8 @@ public class MainActivity extends BaseActivity implements MainContract.View {
         mPresenter.setAdapterView(mAdapter);
         mPresenter.setAdapterModel(mAdapter);
 
-        // Presenter에서 사용될 ImageData setup.
-        mPresenter.setImageData(ImageData.getInstance());
+        // Presenter에서 사용 될 Repository (Model) setup.
+        mPresenter.setImageData(ImageRepository.getInstance());
     }
 
     private void setupRefreshLayout() {
@@ -71,7 +71,7 @@ public class MainActivity extends BaseActivity implements MainContract.View {
 
     @Override
     public void updateRefresh() {
-        Log.i(TAG, "Presenter -> View: UI 갱신 요청 이벤트 [ refresh 처리 ]");
+        Log.i(TAG, "View: Presenter로 부터 UI 갱신 요청 받음. [ RefreshLayout 처리 ]");
 
         if (refreshLayout.isRefreshing()) {
             refreshLayout.setRefreshing(false);
@@ -80,7 +80,7 @@ public class MainActivity extends BaseActivity implements MainContract.View {
 
     @Override
     public void showToast(String message) {
-        Log.i(TAG, "Presenter -> View: UI 갱신 요청 이벤트. [ toast 처리 ]");
+        Log.i(TAG, "View: Presenter로 부터 UI 갱신 요청 받음. [ Toast 처리 ]");
 
         Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
     }

--- a/app/src/main/java/com/dev_juyoung/cro_mvp_sample/MainContract.java
+++ b/app/src/main/java/com/dev_juyoung/cro_mvp_sample/MainContract.java
@@ -2,7 +2,7 @@ package com.dev_juyoung.cro_mvp_sample;
 
 import android.content.Context;
 
-import com.dev_juyoung.cro_mvp_sample.data.ImageData;
+import com.dev_juyoung.cro_mvp_sample.data.ImageRepository;
 
 /**
  * Created by juyounglee on 2017. 11. 6..
@@ -18,7 +18,7 @@ public interface MainContract {
         void setView(View view);
         void setAdapterView(ImageAdapterContract.View adapterView);
         void setAdapterModel(ImageAdapterContract.Model adapterModel);
-        void setImageData(ImageData imageData);
+        void setImageData(ImageRepository repository);
         void updateData(Context context, boolean isUpdate);
     }
 }

--- a/app/src/main/java/com/dev_juyoung/cro_mvp_sample/MainPresenter.java
+++ b/app/src/main/java/com/dev_juyoung/cro_mvp_sample/MainPresenter.java
@@ -3,7 +3,8 @@ package com.dev_juyoung.cro_mvp_sample;
 import android.content.Context;
 import android.util.Log;
 
-import com.dev_juyoung.cro_mvp_sample.data.ImageData;
+import com.dev_juyoung.cro_mvp_sample.data.ImageRepository;
+import com.dev_juyoung.cro_mvp_sample.data.ImageSource;
 import com.dev_juyoung.cro_mvp_sample.utils.OnItemClickListener;
 
 import java.util.ArrayList;
@@ -18,7 +19,7 @@ public class MainPresenter implements MainContract.Presenter, OnItemClickListene
     private MainContract.View view;
     private ImageAdapterContract.View adapterView;
     private ImageAdapterContract.Model adapterModel;
-    private ImageData imageData;
+    private ImageRepository repository;
 
     @Override
     public void setView(MainContract.View view) {
@@ -37,32 +38,37 @@ public class MainPresenter implements MainContract.Presenter, OnItemClickListene
     }
 
     @Override
-    public void setImageData(ImageData imageData) {
-        this.imageData = imageData;
+    public void setImageData(ImageRepository repository) {
+        this.repository = repository;
     }
 
     @Override
-    public void updateData(Context context, boolean isUpdate) {
-        Log.i(TAG, "View -> Presenter: 데이터 갱신 요청 이벤트.");
+    public void updateData(Context context, final boolean isUpdate) {
+        Log.i(TAG, "Presenter: View로 부터 데이터 갱신 요청.");
 
-        ArrayList<Integer> items = imageData.getImages(context, 10);
+        repository.getImages(context, 10, new ImageSource.LoadImageCallback() {
+            @Override
+            public void onImageLoaded(ArrayList<Integer> items) {
+                Log.i(TAG, "Presenter: Callback을 통해 Model에서 처리된 데이터를 전달 받음.");
 
-        // update 유무에 따른 adapterModel 갱신.
-        if (!isUpdate) {
-            adapterModel.addItems(items);
-        } else {
-            adapterModel.updateItems(items);
-        }
+                // update 유무에 따른 adapterModel 갱신.
+                if (!isUpdate) {
+                    adapterModel.addItems(items);
+                } else {
+                    adapterModel.updateItems(items);
+                }
 
-        // adapterView UI 갱신 이벤트 전달.
-        adapterView.updateView();
-        // view에 UI 갱신 이벤트 전달.
-        view.updateRefresh();
+                // adapterView UI 갱신 이벤트 전달.
+                adapterView.updateView();
+                // view에 UI 갱신 이벤트 전달.
+                view.updateRefresh();
+            }
+        });
     }
 
     @Override
     public void onItemClick(int position) {
-        Log.i(TAG, "AdapterView -> Presenter: 사용자 클릭 이벤트에 따른 로직 처리. [ model로 데이터 요청 or Activity 전환 등 ]");
+        Log.i(TAG, "Presenter: AdapterView로 부터 사용자 클릭 이벤트 전달 받음. [model 접근 또는 Activity 전환 등 추가 로직 처리] ");
 
         String formattedMessage = String.format("현재 선택된 Item의 Position: %d", position);
         view.showToast(formattedMessage);

--- a/app/src/main/java/com/dev_juyoung/cro_mvp_sample/data/ImageLocalDataSource.java
+++ b/app/src/main/java/com/dev_juyoung/cro_mvp_sample/data/ImageLocalDataSource.java
@@ -6,22 +6,25 @@ import android.util.Log;
 import java.util.ArrayList;
 
 /**
- * Created by juyounglee on 2017. 11. 3..
+ * Created by juyounglee on 2017. 11. 6..
  */
 
-public class ImageData {
-    private static final String TAG = "ImageData";
-    private static ImageData instance;
+public class ImageLocalDataSource implements ImageSource {
+    private static final String TAG = "ImageLocalDataSource";
 
-    public static ImageData getInstance() {
+    private static ImageLocalDataSource instance;
+
+    public static ImageLocalDataSource getInstance() {
         if (instance == null) {
-            instance = new ImageData();
+            instance = new ImageLocalDataSource();
         }
+
         return instance;
     }
 
-    public ArrayList<Integer> getImages(Context context, int size) {
-        Log.i(TAG, "Presenter -> Model: 데이터 요청 이벤트.");
+    @Override
+    public void getImages(Context context, int size, LoadImageCallback callback) {
+        Log.i(TAG, "LocalDataSource(Model): Repository의 요청에 따라 Local 저장소에서 요청된 데이터를 처리함.");
 
         ArrayList<Integer> items = new ArrayList<>();
 
@@ -34,6 +37,8 @@ public class ImageData {
             items.add(resourceId);
         }
 
-        return items;
+        if (callback != null) {
+            callback.onImageLoaded(items);
+        }
     }
 }

--- a/app/src/main/java/com/dev_juyoung/cro_mvp_sample/data/ImageRepository.java
+++ b/app/src/main/java/com/dev_juyoung/cro_mvp_sample/data/ImageRepository.java
@@ -1,0 +1,36 @@
+package com.dev_juyoung.cro_mvp_sample.data;
+
+import android.content.Context;
+import android.util.Log;
+
+/**
+ * Created by juyounglee on 2017. 11. 6..
+ */
+
+public class ImageRepository implements ImageSource {
+    private static final String TAG = "ImageRepository";
+
+    private static ImageRepository instance;
+
+    private ImageLocalDataSource localDataSource;
+
+    public static ImageRepository getInstance() {
+        if (instance == null) {
+            instance = new ImageRepository();
+        }
+
+        return instance;
+    }
+
+    public ImageRepository() {
+        localDataSource = ImageLocalDataSource.getInstance();
+    }
+
+
+    @Override
+    public void getImages(Context context, int size, LoadImageCallback callback) {
+        Log.i(TAG, "Repository(Model): Presenter의 데이터 요청에 따른 로직 처리. [상황에 맞게 Local || Remote 데이터를 처리하도록 선택적으로 요청.]");
+
+        localDataSource.getImages(context, size, callback);
+    }
+}

--- a/app/src/main/java/com/dev_juyoung/cro_mvp_sample/data/ImageSource.java
+++ b/app/src/main/java/com/dev_juyoung/cro_mvp_sample/data/ImageSource.java
@@ -1,0 +1,22 @@
+package com.dev_juyoung.cro_mvp_sample.data;
+
+import android.content.Context;
+
+import java.util.ArrayList;
+
+/**
+ * Created by juyounglee on 2017. 11. 6..
+ */
+
+public interface ImageSource {
+
+    /**
+     * Local 또는 Remote에서 데이터를 불러 온 후의 처리를 위한 Callback Methods.
+     * 성공 / 실패 등 필요에 따라 Method는 생성한다.
+     */
+    interface LoadImageCallback {
+        void onImageLoaded(ArrayList<Integer> items);
+    }
+
+    void getImages(Context context, int size, LoadImageCallback callback);
+}


### PR DESCRIPTION
기존의 MVC Pattern 에서 Model을 분리함.

* DataSource Interface 선언: Callback Interface와 Repository 및 DataSource에서 필요한 기능 선언.
* Repository: DataSource를 implement하여 상황에 따라 Local / Remote로 데이터 요청 및 Presenter로 Callback 넘겨줌.
* Local or Remote DataSource Class 선언: DataSource interface를 implement하여 Local과 Remote에서 데이터를 처리하고, 결과값을 Callback으로 넘겨준다.